### PR TITLE
Fix example Makefile for `clang`.

### DIFF
--- a/example_makefile/.gitignore
+++ b/example_makefile/.gitignore
@@ -1,0 +1,3 @@
+common.o
+program1
+program2

--- a/example_makefile/Makefile
+++ b/example_makefile/Makefile
@@ -1,12 +1,14 @@
 CFLAGS = -std=gnu11 -Wall -Werror -Wextra
 
-.PHONY: all clean
-
+.PHONY: all
 all: program1 program2
 
+.PHONY: clean
 clean:
 	$(RM) common.o program1 program2
 
-program1: common.o program1.c
+common.o: common.c common.h
 
-program2: common.o program2.c
+program1: program1.c common.o
+
+program2: program2.c common.o

--- a/example_makefile/Makefile
+++ b/example_makefile/Makefile
@@ -5,8 +5,8 @@ CFLAGS = -std=gnu11 -Wall -Werror -Wextra
 all: program1 program2
 
 clean:
-	$(RM) program1 program2 common.o
+	$(RM) common.o program1 program2
 
-program1: program1.c common.h common.o
+program1: common.o program1.c
 
-program2: program2.c common.h common.o
+program2: common.o program2.c


### PR DESCRIPTION
When also including the header, `clang` fails with:

```
clang: error: cannot specify -o when generating multiple output files
```
